### PR TITLE
Enhance Player Queue Ordering and Scrolling in GamePage

### DIFF
--- a/src/pages/RoomPage.js
+++ b/src/pages/RoomPage.js
@@ -6,7 +6,7 @@ import "../styles/RoomPage.scss";
 import arrow_back from "../img/icons/arrow-back.svg";
 import cancel from "../img/icons/cancel.svg";
 
-const socket = io("http://192.168.1.19:3001");
+const socket = io("http://192.168.1.6:3001");
 // const socket = io("https://5158-176-128-221-167.ngrok-free.app", {
 //   transports: ["websocket"],
 // });

--- a/src/styles/GamePage.scss
+++ b/src/styles/GamePage.scss
@@ -21,6 +21,7 @@
   // Section des joueurs en haut
   .game-players {
     display: flex;
+    overflow: auto;
     justify-content: space-around;
     width: 100%;
     animation: slideDown 1.5s;
@@ -35,9 +36,11 @@
       background-color: #f0f0f0;
       color: #000;
       padding: 10px;
+      justify-content: center;
       border-radius: 8px;
+      min-width: 100px;
 
-      &.itsTurn {
+      &:nth-child(2) {
         background-color: var(--primary);
         color: #fff;
       }
@@ -51,7 +54,6 @@
       }
 
       .player-name {
-        margin-top: 5px;
         font-size: 0.9rem;
         font-weight: 600;
       }


### PR DESCRIPTION
This pull request adds a player queue ordering system with scrolling support. It introduces `getOrderedPlayerUsernames` to determine player turn order, integrates a socket trigger to fetch the ordered list using the room ID, improves error handling, and updates the UI to allow scrolling while keeping the current player in the second position.

#### **Functionality Enhancements:**  
- **`app.js`**  
  - Added `getOrderedPlayerUsernames` to return the ordered list of player turns, ensuring a fixed display order.  
  - Integrated the socket trigger using `getOrderedPlayerUsernames` with the room ID.  
  - Implemented error handling for better resilience.  

- **`GamePage.js`**  
  - Introduced a `useState` hook (`orderedUsernames`) to store and manage player order.  
  - Implemented `socket.emit("getOrderedPlayerUsernames", { roomId })` to refresh the player list dynamically.  

#### **Styling Adjustments:**  
- **`GamePage.scss`**  
  - Enabled scrolling for the player list while ensuring the current player remains in the second position.  